### PR TITLE
Render to terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,7 @@ dependencies = [
  "js-sys 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped_css 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smithy 0.0.7",
+ "termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-futures 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-test 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -187,6 +188,11 @@ dependencies = [
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "numtoa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
@@ -218,6 +224,19 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "redox_termios"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -388,6 +407,17 @@ dependencies = [
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -600,10 +630,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum memory_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum nom 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e9761d859320e381010a4f7f8ed425f2c924de33ad121ace447367c713ad561b"
+"checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c5c2380ae88876faae57698be9e9775e3544decad214599c3a6266cca6ac802"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+"checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
+"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
@@ -620,6 +653,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "158521e6f544e7e3dcfc370ac180794aa38cb34a1b1e07609376d4adcf429b93"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
+"checksum termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a8fb22f7cde82c8220e5aeacb3258ed7ce996142c77cba193f203515e26c330"
 "checksum unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ web-sys = { version = "0.3.22", features = [
 # in debug mode.
 console_error_panic_hook = "0.1.5"
 scoped_css = "0.0.1"
+termion = "1.5.3"
 
 # These crates are used for running unit tests.
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,14 +22,23 @@ fn get_root_element() -> Result<web_sys::Element, wasm_bindgen::JsValue> {
 // This is the entry point of your app
 #[wasm_bindgen(start)]
 pub fn start() -> Result<(), wasm_bindgen::JsValue> {
+  use smithy::types::Component;
+  use smithy::*;
+  
+  // use smithy_types::core::AsInnerHtml
   console_error_panic_hook::set_once();
 
-  let root_element = get_root_element()?;
+  // let root_element = get_root_element()?;
 
   let board = game::Board::empty();
-  let app = app::render(board);
+  let mut app = app::render(board);
 
-  smithy::mount(Box::new(app), root_element);
+  let node = app.render();
+  let collapsed_node_vec: Vec<smithy::types::CollapsedNode> = node.into();
+
+  web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(&collapsed_node_vec.as_inner_html()));
+
+  // smithy::mount(Box::new(app), root_element);
 
   Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,30 +1,33 @@
 #![feature(proc_macro_hygiene, slice_patterns)]
 
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+// #[global_allocator]
+// static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 mod app;
 mod game;
 
-use wasm_bindgen::prelude::wasm_bindgen;
+// use wasm_bindgen::prelude::wasm_bindgen;
 
-fn get_root_element() -> Result<web_sys::Element, wasm_bindgen::JsValue> {
-  web_sys::window()
-    .and_then(|w| w.document())
-    // N.B. query_selector returns Result<Option<Element>>
-    // So, calling .ok() on that converts it to an Option<Option<Element>>
-    // and hence, we must call .ok_or() twice.
-    .and_then(|d| d.query_selector("#app").ok())
-    .ok_or(wasm_bindgen::JsValue::NULL)?
-    .ok_or(wasm_bindgen::JsValue::NULL)
-}
+// fn get_root_element() -> Result<web_sys::Element, wasm_bindgen::JsValue> {
+//   web_sys::window()
+//     .and_then(|w| w.document())
+//     // N.B. query_selector returns Result<Option<Element>>
+//     // So, calling .ok() on that converts it to an Option<Option<Element>>
+//     // and hence, we must call .ok_or() twice.
+//     .and_then(|d| d.query_selector("#app").ok())
+//     .ok_or(wasm_bindgen::JsValue::NULL)?
+//     .ok_or(wasm_bindgen::JsValue::NULL)
+// }
 
 // This is the entry point of your app
-#[wasm_bindgen(start)]
-pub fn start() -> Result<(), wasm_bindgen::JsValue> {
-  use smithy::types::Component;
-  use smithy::*;
-  
+// #[wasm_bindgen(start)]
+// pub fn start() -> Result<(), wasm_bindgen::JsValue> {
+pub fn main() {
+  use smithy::{
+    types::Component,
+    *,
+  };
+
   // use smithy_types::core::AsInnerHtml
   console_error_panic_hook::set_once();
 
@@ -36,9 +39,10 @@ pub fn start() -> Result<(), wasm_bindgen::JsValue> {
   let node = app.render();
   let collapsed_node_vec: Vec<smithy::types::CollapsedNode> = node.into();
 
-  web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(&collapsed_node_vec.as_inner_html()));
+  // web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(&collapsed_node_vec.as_inner_html()));
+  println!("{}", collapsed_node_vec.as_inner_html());
 
   // smithy::mount(Box::new(app), root_element);
 
-  Ok(())
+  // Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,87 @@
+#![feature(proc_macro_hygiene, slice_patterns)]
+
+// #[global_allocator]
+// static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+
+mod app;
+mod game;
+
+// use wasm_bindgen::prelude::wasm_bindgen;
+
+// fn get_root_element() -> Result<web_sys::Element, wasm_bindgen::JsValue> {
+//   web_sys::window()
+//     .and_then(|w| w.document())
+//     // N.B. query_selector returns Result<Option<Element>>
+//     // So, calling .ok() on that converts it to an Option<Option<Element>>
+//     // and hence, we must call .ok_or() twice.
+//     .and_then(|d| d.query_selector("#app").ok())
+//     .ok_or(wasm_bindgen::JsValue::NULL)?
+//     .ok_or(wasm_bindgen::JsValue::NULL)
+// }
+
+// This is the entry point of your app
+// #[wasm_bindgen(start)]
+// pub fn start() -> Result<(), wasm_bindgen::JsValue> {
+
+use smithy::*;
+fn print_to_console(app: &mut smithy::types::SmithyComponent) {
+  let node = app.render();
+  let collapsed_node_vec: Vec<smithy::types::CollapsedNode> = node.into();
+
+  // web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(&collapsed_node_vec.as_inner_html()));
+  println!("{}", collapsed_node_vec.as_inner_html());
+  println!("\n\n----\n\n");
+}
+
+struct Terminal {}
+
+impl RenderingTarget for Terminal {
+  fn render(&self, nodes: &Vec<CollapsedNode>) {
+    println!("{}", nodes.as_inner_html());
+    println!("----\n\n");
+  }
+
+  fn apply_diff(&self, nodes: &Vec<CollapsedNode>) {
+    println!("applied diff");
+    self.render(nodes);
+  }
+
+  fn attach_listeners(&self) {}
+}
+
+pub fn main() {
+  use smithy::types::Component;
+
+  // use smithy_types::core::AsInnerHtml
+  // console_error_panic_hook::set_once();
+
+  // let root_element = get_root_element()?;
+
+  // let board = game::Board::empty();
+  // let mut app = app::render(board);
+
+  let mut count = 0;
+  let mut app = smithy::smd!(
+    <text on_test={|_| count += 1}>count: <text color="red">{ count }</text></text>
+  );
+
+  // let node = app.render();
+  // let collapsed_node_vec: Vec<smithy::types::CollapsedNode> = node.into();
+
+  // // web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(&collapsed_node_vec.as_inner_html()));
+  // println!("{}", collapsed_node_vec.as_inner_html());
+  // print_to_console(&mut app);
+
+  let terminal = Terminal {};
+  smithy::mount(Box::new(app), Box::new(terminal));
+  // println!("\n\n----\n\n");
+
+  smithy::handle_ui_event(&smithy::types::UiEvent::OnTest(true), &vec![0]);
+  smithy::rerender();
+
+  // print_to_console(&mut app);
+
+  // app.handle_ui_event()
+
+  // Ok(())
+}


### PR DESCRIPTION
What did we do?

* Comment out all references to web_sys and wasm_bindgen, on the theory that they won't compile when built for a regular target
* implement `RenderingTarget` for the `Terminal` struct. `RenderingTarget` was added in https://github.com/rbalicki2/smithy/pull/6
* Result: it logs to the console and handles events! 🎉 